### PR TITLE
Alias Api Client

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@services/*": ["./src/services/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/page.tsx", "src/app/layout.tsx"],


### PR DESCRIPTION
This PR adds an alias to the apiClient path to make it easier to import.

### Example: 

```typescript
import { apiBackend } from "@services/ApiClient"; 
``` 